### PR TITLE
build: Ignore WebStorm non-shareable config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ _site
 .jekyll-metadata
 vendor
 *~
+.idea/workspace.xml
+.idea/usage.statistics.xml
+.idea/dictionaries
+.idea/shelf


### PR DESCRIPTION
List from https://www.jetbrains.com/help/webstorm/2026.1/creating-and-managing-projects.html?help.content.roots.folder.categories&keymap=KDE#list-of-ignored-files