### PR TITLE
feat: Add Digital Asset Links file

### DIFF
--- a/.well-known/assetlinks.json
+++ b/.well-known/assetlinks.json
@@ -1,0 +1,14 @@
+[
+  {
+    "relation": ["delegate_permission/org.privacyguides.verifiedapps"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "app.pachli",
+      "sha256_cert_fingerprints": [
+        "F0:CD:1F:5C:FF:49:9B:E4:C2:12:8C:11:52:FB:91:9D:C2:48:15:15:2A:99:03:C9:09:4F:F8:40:5F:E1:31:C3",
+        "F0:2E:56:BC:59:61:14:8E:C5:21:E1:7A:B3:1D:F7:1F:D4:F0:7A:35:CD:CF:6C:60:12:8C:9B:A5:6A:06:E0:04",
+        "89:E2:8F:70:4B:55:ED:1A:A5:FC:30:F0:25:5C:59:B1:C8:9D:2F:6E:20:C7:F7:26:45:17:AA:05:C7:74:3E:3C"
+      ]
+    }
+  }
+]

--- a/_config.yml
+++ b/_config.yml
@@ -61,6 +61,8 @@ plugins:
   - jekyll-local-theme
   - jekyll-seo-tag
 
+include: [".well-known"]
+
 # Exclude from processing.
 # The following items will not be processed, by default.
 # Any item listed under the `exclude:` key here will be automatically added to


### PR DESCRIPTION
The file at /.well-known/assetlinks.json verifies the domain used in Pachli's package ID.

- F0:CD:... is the Pachli signing key
- F0:2E:... is the F-Droid signing key
- 89:E2:... is the Google Play signing key