### PR TITLE
chore(deps): Update commonmarker to 0.23.12

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,7 @@ GEM
       execjs
     coffee-script-source (1.11.1)
     colorator (1.1.0)
-    commonmarker (0.23.11)
+    commonmarker (0.23.12)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     dnsruby (1.72.4)


### PR DESCRIPTION
0.23.11 has problems on newer GCC versions (see
https://github.com/gjtorikian/commonmarker/issues/394 for details), fixed in 0.23.12.